### PR TITLE
fix(examples): Updated trace property

### DIFF
--- a/quarkus-ssl/src/main/resources/application.yaml
+++ b/quarkus-ssl/src/main/resources/application.yaml
@@ -72,11 +72,9 @@ quarkus:
 camel:
   context:
     name: SampleCamel
-  main:
+  trace:
     # Uncomment these properties to enable the Camel plugin Trace tab
-    #tracing: true
-    #backlogTracing: true
-    #useBreadcrumb: true
+    #enabled: true
 
 quartz:
   cron: 0/10 * * * * ?

--- a/springboot-ssl/src/main/resources/application.yaml
+++ b/springboot-ssl/src/main/resources/application.yaml
@@ -59,10 +59,9 @@ hawtio:
 camel:
   springboot:
     name: SampleCamel
+  trace:
     # Uncomment these properties to enable the Camel plugin Trace tab
-    #tracing: true
-    #backlog-tracing: true
-    #use-breadcrumb: true
+    #enabled: true
 
 quartz:
   cron: 0/10 * * * * ?


### PR DESCRIPTION
Related: https://github.com/hawtio/hawtio/pull/3917

Updates the trace properties in the examples to use current 4.5 property camel.trace.enabled

https://camel.apache.org/manual/camel-4x-upgrade-guide-4_5.html#_camel_spring_boot